### PR TITLE
fix: Breaking changes of NimBLE-Arduino v2

### DIFF
--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -10,6 +10,8 @@
 
 #include "NimBLECharacteristic.h"
 #include "NimBLEHIDDevice.h"
+#include "NimBLEAdvertising.h"
+#include "NimBLEServer.h"
 
 #define BLEDevice                  NimBLEDevice
 #define BLEServerCallbacks         NimBLEServerCallbacks
@@ -138,8 +140,8 @@ private:
   BLEAdvertising*    advertising;
   KeyReport          _keyReport;
   MediaKeyReport     _mediaKeyReport;
-  std::string        deviceName;
-  std::string        deviceManufacturer;
+  String        deviceName;
+  String        deviceManufacturer;
   uint8_t            batteryLevel;
   bool               connected = false;
   uint32_t           _delay_ms = 7;
@@ -150,7 +152,7 @@ private:
   uint16_t version   = 0x0210;
 
 public:
-  BleKeyboard(std::string deviceName = "ESP32 Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
+  BleKeyboard(String deviceName = "ESP32 Keyboard", String deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
   void begin(void);
   void end(void);
   void sendReport(KeyReport* keys);
@@ -165,7 +167,7 @@ public:
   void releaseAll(void);
   bool isConnected(void);
   void setBatteryLevel(uint8_t level);
-  void setName(std::string deviceName);  
+  void setName(String deviceName);
   void setDelay(uint32_t ms);
 
   void set_vendor_id(uint16_t vid);
@@ -173,9 +175,16 @@ public:
   void set_version(uint16_t version);
 protected:
   virtual void onStarted(BLEServer *pServer) { };
+
+  #if defined(USE_NIMBLE)
+  virtual void onConnect(BLEServer* pServer, NimBLEConnInfo & connInfo) override;
+  virtual void onDisconnect(BLEServer* pServer, NimBLEConnInfo & connInfo, int reason) override;
+  virtual void onWrite(BLECharacteristic* me, NimBLEConnInfo & connInfo) override;
+  #else
   virtual void onConnect(BLEServer* pServer) override;
   virtual void onDisconnect(BLEServer* pServer) override;
   virtual void onWrite(BLECharacteristic* me) override;
+  #endif // USE_NIMBLE
 
 };
 


### PR DESCRIPTION
# Description

Absolute bonkers of a code BUT it works lol. Currently, just fixed the compatibility with NimBLE-Arduino 2.2.3 and addressed the breaking changes. Seems to be working.

With no clue of how things work on the device/embedded level and some frustrated prompting, fighting with the AI tool, got a working version and also has a little idea of things now.

AI helped me find [this migration guide](https://itsblue.dev/ScStw/esp-nimble-cpp/src/commit/efa858c4cc14f3da01017f951b165f50642bf3fa/docs/Migration_guide.md#client-callbacks) and it explains how 0x2902 descriptor is handled automatically by NimBLE stack. Whatever that means :p

I will address with proper coding technique in a separate PR. Until then, trash code it is.