### PR TITLE
#ifdef so it doesn't get compiled if not actually used

### DIFF
--- a/NimBleKeyboard.cpp
+++ b/NimBleKeyboard.cpp
@@ -1,4 +1,6 @@
 // NimbleKeyboard.cpp
+#if defined(USE_NIMBLE)
+
 #include "NimBleKeyboard.h"
 
 NimBleKeyboard::NimBleKeyboard(String name, String manufacturer, uint8_t battery)
@@ -243,3 +245,5 @@ void NimBleKeyboard::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo & connIn
 void NimBleKeyboard::onWrite(NimBLECharacteristic* me, NimBLEConnInfo & connInfo) {
     // Not used
 }
+
+#endif


### PR DESCRIPTION
I appreciate your work in tidying up these compiler errors. I'm trying to build some old code that does not use the NimBLE library, and I had to #ifdef out the contents of one of your files to avoid getting linking errors.