### PR TITLE
feat: Enhance BLE lifecycle management and connection control

### DIFF
--- a/NimBleKeyboard.cpp
+++ b/NimBleKeyboard.cpp
@@ -76,6 +76,12 @@ void NimBleKeyboard::stopAdvertising() {
     }
 }
 
+void NimBleKeyboard::clearBonds() {
+    if (initialized) {
+        int result = NimBLEDevice::deleteAllBonds();
+    }
+}
+
 void NimBleKeyboard::startAdvertising() {
     if (advertising) {
         advertising->start();

--- a/NimBleKeyboard.h
+++ b/NimBleKeyboard.h
@@ -540,6 +540,18 @@ public:
      */
     void stopAdvertising();
 
+    /**
+     * @brief Clear all bonded devices from NVS storage
+     *
+     * Deletes stored bonding keys to force fresh pairing.
+     * Use case: User wants to pair with a NEW device and prevent
+     * auto-reconnect from previously bonded devices.
+     *
+     * Note: This affects ALL bonded devices (NimBLE limitation).
+     * Must be called when BLE is initialized.
+     */
+    void clearBonds();
+
 private:
     NimBLEServer* pServer;
     NimBLEHIDDevice* hid;

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Added vertical and horizontal scrolling capabilities, as a mouse. I know there i
 - **Connection callbacks**: Added `setOnConnect()` and `setOnDisconnect()` methods to register callbacks for connection state changes
 - **Advertising control**: Added `startAdvertising()` and `stopAdvertising()` methods for manual control over BLE advertising
 - **Manual disconnect**: Added `disconnect()` method to programmatically disconnect connected devices
+- **Bond management**: Added `clearBonds()` method to clear all bonded devices from NVS storage, enabling fresh pairing with a new device without auto-reconnect from previously paired devices
 - **Proper BLE shutdown**: Implemented `end()` method to properly deinitialize the BLE stack and free resources
 - **Documentation**: Added comprehensive API documentation to header files
 

--- a/StandardBleKeyboard.cpp
+++ b/StandardBleKeyboard.cpp
@@ -2,6 +2,7 @@
 #include "esp_bt_main.h"
 #include "esp_gap_ble_api.h"
 #include "esp_gatts_api.h"
+#include "esp_bt_device.h"
 
 StandardBleKeyboard::StandardBleKeyboard(String name, String manufacturer, uint8_t battery)
     : deviceName(name), deviceManufacturer(manufacturer), batteryLevel(battery) {
@@ -75,6 +76,31 @@ void StandardBleKeyboard::begin() {
 void StandardBleKeyboard::stopAdvertising() {
     if (advertising) {
         advertising->stop();
+    }
+}
+
+void StandardBleKeyboard::clearBonds() {
+    if (initialized) {
+        // Get the number of bonded devices
+        int dev_num = esp_ble_get_bond_device_num();
+
+        if (dev_num > 0) {
+            // Allocate memory for the bonded device list
+            esp_ble_bond_dev_t *dev_list = (esp_ble_bond_dev_t *)malloc(sizeof(esp_ble_bond_dev_t) * dev_num);
+
+            if (dev_list != NULL) {
+                // Get the list of all bonded devices
+                esp_ble_get_bond_device_list(&dev_num, dev_list);
+
+                // Remove each bonded device
+                for (int i = 0; i < dev_num; i++) {
+                    esp_ble_remove_bond_device(dev_list[i].bd_addr);
+                }
+
+                // Free allocated memory
+                free(dev_list);
+            }
+        }
     }
 }
 

--- a/StandardBleKeyboard.h
+++ b/StandardBleKeyboard.h
@@ -534,6 +534,18 @@ public:
      */
     void stopAdvertising();
 
+    /**
+     * @brief Clear all bonded devices from NVS storage
+     *
+     * Deletes stored bonding keys to force fresh pairing.
+     * Use case: User wants to pair with a NEW device and prevent
+     * auto-reconnect from previously bonded devices.
+     *
+     * Note: This affects ALL bonded devices.
+     * Must be called when BLE is initialized.
+     */
+    void clearBonds();
+
 private:
     BLEServer* pServer;
     BLEHIDDevice* hid;

--- a/examples/DeviceSwitching/DeviceSwitching.ino
+++ b/examples/DeviceSwitching/DeviceSwitching.ino
@@ -1,0 +1,70 @@
+/**
+ * This example demonstrates how to switch between paired devices
+ * using clearBonds() to prevent auto-reconnect from the previous device.
+ *
+ * Use Case: You want to pair with a new device (Phone B) but the old
+ * device (Phone A) keeps auto-reconnecting when you disconnect.
+ *
+ * Flow:
+ * 1. Device pairs with Phone A and sends keystrokes
+ * 2. After 15 seconds, initiates device switching
+ * 3. Disconnects from Phone A
+ * 4. Clears bonding info (prevents Phone A from auto-reconnecting)
+ * 5. Starts advertising for Phone B to pair
+ * 6. Once Phone B connects, sends keystrokes to Phone B
+ */
+#include <BleKeyboard.h>
+
+BleKeyboard bleKeyboard;
+unsigned long connectionTime = 0;
+bool hasSwitchedDevice = false;
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("Starting BLE Device Switching Example...");
+  Serial.println("Pair with your first device (Phone A) now");
+  bleKeyboard.begin();
+}
+
+void loop() {
+  if(bleKeyboard.isConnected()) {
+    if(connectionTime == 0) {
+      connectionTime = millis();
+      if(!hasSwitchedDevice) {
+        Serial.println("Phone A connected!");
+        Serial.println("Sending test message to Phone A...");
+        bleKeyboard.println("Hello from ESP32 - Device A");
+      } else {
+        Serial.println("Phone B connected!");
+        Serial.println("Sending test message to Phone B...");
+        bleKeyboard.println("Hello from ESP32 - Device B");
+        Serial.println("Device switching successful!");
+      }
+    }
+
+    // After 15 seconds connected to Phone A, switch to Phone B
+    if(!hasSwitchedDevice && (millis() - connectionTime > 15000)) {
+      Serial.println("\n--- Switching to new device ---");
+      Serial.println("Step 1: Disconnecting from Phone A...");
+      bleKeyboard.disconnect();
+      delay(200);
+
+      Serial.println("Step 2: Clearing bonding info...");
+      bleKeyboard.clearBonds();
+      delay(200);
+
+      Serial.println("Step 3: Starting advertising for Phone B...");
+      bleKeyboard.startAdvertising();
+
+      Serial.println("Phone A will NOT auto-reconnect.");
+      Serial.println("Pair with your second device (Phone B) now");
+
+      hasSwitchedDevice = true;
+      connectionTime = 0;
+    }
+  } else {
+    connectionTime = 0;
+  }
+
+  delay(1000);
+}


### PR DESCRIPTION
# Description
## Summary

  - Add `clearBonds()` method to manage bonded device connections
  - Enable device switching without auto-reconnect from previous devices
  - Include example demonstrating device switching workflow

## Motivation

  When switching between paired devices (e.g., Phone A to Phone B), previously bonded devices automatically reconnect, preventing new pairings. This PR adds bond clearing functionality to solve this issue.

## Changes

  Core Functionality
  - Added `clearBonds()` to `NimBleKeyboard (NimBleKeyboard.cpp:79)` using NimBLE API
  - Added `clearBonds()` to `StandardBleKeyboard (StandardBleKeyboard.cpp:82)` using ESP-IDF GAP API
  - Clears all stored bonding keys from NVS storage

## Documentation & Examples
  - Updated README with bond management feature
  - Added `examples/DeviceSwitching/DeviceSwitching.ino` showing complete device switching workflow

## Usage
````
  bleKeyboard.disconnect();
  bleKeyboard.clearBonds();  // Prevents old device from auto-reconnecting
  bleKeyboard.startAdvertising();  // Ready for new device pairing
````
